### PR TITLE
Fix Semaphore queue size limit and optimize walkDir recursion

### DIFF
--- a/cli/src/runtime/SelfModifyingEngine.ts
+++ b/cli/src/runtime/SelfModifyingEngine.ts
@@ -45,6 +45,8 @@ export interface MutationResult {
 export interface SelfModifyingEngineConfig {
     /** Max concurrent directory scans (default: 50) */
     concurrencyLimit?: number;
+    /** Max items in semaphore queue (default: Infinity) */
+    maxQueueSize?: number;
     /** Diretório raiz do código fonte */
     sourceDir: string;
     /** Diretório para backups */
@@ -67,6 +69,7 @@ export interface SelfModifyingEngineConfig {
 
 const DEFAULT_CONFIG: Required<Omit<SelfModifyingEngineConfig, 'sourceDir'>> = {
     concurrencyLimit: 50,
+    maxQueueSize: Infinity,
     backupDir: '.ouroboros/backups',
     validateSyntax: true,
     runTestsAfter: true,
@@ -102,7 +105,7 @@ export class SelfModifyingEngine {
         }
         this.config.concurrencyLimit = limit;
 
-        this.semaphore = new Semaphore(this.config.concurrencyLimit, Math.max(2048, this.config.concurrencyLimit * 100));
+        this.semaphore = new Semaphore(this.config.concurrencyLimit, this.config.maxQueueSize);
     }
 
     // ========================================================================
@@ -487,13 +490,17 @@ export class SelfModifyingEngine {
             }
         }
 
-        // Recurse into directories in parallel
+        // Recurse into directories in parallel, batched
         if (directories.length > 0) {
-            const results = await Promise.all(
-                directories.map(d => this.walkDir(d))
-            );
-            for (const result of results) {
-                files.push(...result);
+            const batchSize = this.config.concurrencyLimit;
+            for (let i = 0; i < directories.length; i += batchSize) {
+                const batch = directories.slice(i, i + batchSize);
+                const results = await Promise.all(
+                    batch.map(d => this.walkDir(d))
+                );
+                for (const result of results) {
+                    files.push(...result);
+                }
             }
         }
 


### PR DESCRIPTION
- Added `maxQueueSize` to `SelfModifyingEngineConfig` (default: Infinity) to prevent hard crashes on large directory trees.
- Refactored `walkDir` to use batched recursion (chunk size = `concurrencyLimit`) instead of `Promise.all` on all directories at once, reducing memory pressure and potential for "in-flight promise" exhaustion.
- Updated `Semaphore` instantiation to respect the new config.

---
*PR created automatically by Jules for task [11430353414499997584](https://jules.google.com/task/11430353414499997584) started by @RenyEnnos*

## Summary by Sourcery

Limitar o tamanho da fila do semáforo e reduzir a ramificação da recursão na varredura de diretórios para melhorar a robustez em árvores de diretórios grandes.

Melhorias:
- Adicionar `maxQueueSize` configurável à configuração do mecanismo auto-modificável, com padrão infinito.
- Atualizar a inicialização do semáforo para usar o `maxQueueSize` configurável em vez de um valor fixo calculado.
- Agrupar chamadas recursivas de `walkDir` com base no limite de concorrência para reduzir o uso de memória e o número de promises em andamento.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit semaphore queue size and reduce directory walk recursion fan-out to improve robustness on large directory trees.

Enhancements:
- Add configurable maxQueueSize to the self-modifying engine configuration with an infinite default.
- Update semaphore initialization to use the configurable maxQueueSize instead of a fixed computed value.
- Batch recursive walkDir calls based on the concurrency limit to lower memory usage and reduce in-flight promises.

</details>