### PR TITLE
docs: definir NVIDIA NIM como provider BYOK restrito

### DIFF
--- a/docs/adr/ADR-0042-nvidia-nim-experimental-provider.md
+++ b/docs/adr/ADR-0042-nvidia-nim-experimental-provider.md
@@ -1,0 +1,141 @@
+# ADR-0042 — NVIDIA NIM somente como provider experimental
+
+- **Status:** Proposed
+- **Date:** 2026-07-11
+- **Decision owners:** Pedro / Ouroboros maintainers
+- **Research:** `docs/research/nvidia-nim-provider-evaluation-2026-07-11.md`
+- **Related:** #42, #34, #36
+
+## Context
+
+O Ouroboros precisa avaliar se endpoints da NVIDIA podem complementar os providers atuais. O runtime, porém, não possui um contrato único em uso: Groq, Z.AI, Gemini, Antigravity e Ollama são chamados por integrações diferentes, com semânticas distintas de timeout, retries, tools, JSON, configuração, métricas e fallback.
+
+Os endpoints hospedados do NVIDIA API Catalog/NIM usam um formato compatível com Chat Completions da OpenAI, mas as capacidades variam por modelo. A oferta gratuita do NVIDIA Developer Program é destinada a prototipagem, pesquisa, desenvolvimento e testes, não a produção. Quotas públicas estáveis, residência regional e retenção específica não foram confirmadas.
+
+Adicionar NVIDIA diretamente a uma integração existente ou trocar apenas a URL criaria acoplamento e compatibilidade ilusória.
+
+## Decision
+
+O Ouroboros **não adotará NVIDIA NIM como provider principal ou default neste ciclo**.
+
+Será permitido, após aprovação explícita e conclusão das dependências, um provider experimental com estas restrições:
+
+1. `nvidia-nim` será opcional, desligado por padrão e ativado por feature flag.
+2. A integração hospedada será limitada a protótipos e tarefas não sensíveis.
+3. Nenhum código privado, segredo, dado pessoal, dado acadêmico confidencial ou conteúdo marcado como sensível será enviado.
+4. Um contrato mínimo de provider será definido antes do adapter NVIDIA.
+5. Capacidades serão declaradas por modelo; “OpenAI-compatible” não implicará tools, JSON Schema, embeddings ou multimodalidade.
+6. O provider atual permanecerá como primário e rollback.
+7. Nenhum limite de 40 RPM será codificado sem evidência oficial ou observada e registrada.
+8. Rate limits serão configuráveis por provider, modelo e operação.
+9. Retries serão restritos a falhas transitórias, com backoff exponencial, full jitter e respeito a `Retry-After`.
+10. O adapter propagará `AbortSignal`, distinguirá timeout de cancelamento e não registrará conteúdo ou credenciais.
+11. Produção exigirá nova ADR, aprovação de custo/licença, revisão de termos, região, retenção e SLA.
+
+## Minimal provider boundary
+
+O contrato comum deverá normalizar somente o necessário aos fluxos existentes:
+
+- chat não streaming;
+- streaming opcional;
+- tool calls opcionais;
+- usage e finish reason;
+- timeout e cancelamento;
+- status/headers permitidos;
+- erros tipados e retry hints;
+- capability profile por modelo.
+
+Embeddings, reranking, visão e execução de agentes externos não serão forçados no mesmo contrato de chat. Poderão usar portas específicas.
+
+## Error policy
+
+Taxonomia mínima:
+
+- `authentication`
+- `authorization`
+- `invalid_request`
+- `rate_limited`
+- `timeout`
+- `cancelled`
+- `unavailable`
+- `provider_error`
+- `malformed_response`
+
+Cada erro deverá indicar `retryable`, `retryAfterMs` quando conhecido e `fallbackAllowed`.
+
+## Rollout
+
+1. Criar contrato e testes com transport fake.
+2. Adaptar um provider existente sem alterar comportamento externo.
+3. Executar POC NVIDIA isolada com chave fornecida por ambiente.
+4. Registrar capacidades e limites observados.
+5. Implementar adapter experimental somente se a POC passar.
+6. Liberar para allowlist de tarefas não sensíveis.
+7. Avaliar dados de erro, latência, throttling e qualidade antes de qualquer ampliação.
+
+## Rollback
+
+- desligar a feature flag;
+- remover o modelo da allowlist;
+- rotear para o provider anterior;
+- não migrar nem persistir estado específico da NVIDIA;
+- remover o adapter sem alterar memória, sessões ou formatos públicos.
+
+## Consequences
+
+### Positive
+
+- reduz lock-in;
+- impede que diferenças entre modelos virem falhas silenciosas;
+- torna resiliência e observabilidade reutilizáveis;
+- permite obter evidência real sem comprometer o runtime principal;
+- mantém caminho de rollback imediato.
+
+### Negative
+
+- exige trabalho arquitetural antes da POC integrada;
+- adiciona capability profiles e taxonomia de erros;
+- não explora imediatamente todos os modelos do catálogo;
+- o endpoint gratuito não pode atender fluxos sensíveis ou de produção.
+
+### Risks
+
+- o catálogo, modelos ou termos podem mudar;
+- quotas podem variar por conta/modelo;
+- comportamento observado pode divergir da documentação;
+- um adapter OpenAI-style pode esconder parâmetros incompatíveis;
+- fallback automático pode elevar custo ou mascarar falhas sem limites claros.
+
+## Rejected alternatives
+
+### NVIDIA como provider principal
+
+Rejeitada por restrições de produção, ausência de SLA gratuito, quotas não confirmadas, risco de dados e fragmentação interna.
+
+### Trocar `baseUrl` do DirectZAIProvider
+
+Rejeitada porque o loop depende de tool calling e formatos Z.AI; capacidades NVIDIA são por modelo e não equivalentes.
+
+### Criar abstração universal para todos os tipos de IA
+
+Rejeitada por excesso de generalização. Chat, embeddings, reranking e agentes externos possuem contratos diferentes.
+
+### Não investigar NVIDIA
+
+Rejeitada porque uma POC isolada pode produzir evidência útil com baixo risco após as dependências.
+
+## Acceptance gates before implementation
+
+- [ ] Pedro aprova o experimento e qualquer risco/custo.
+- [ ] Baseline da #34 permite nova integração.
+- [ ] Contrato mínimo e capability profiles aprovados.
+- [ ] Configuração e segredo centralizados.
+- [ ] POC não integrada comprova autenticação, chat, streaming e cancelamento.
+- [ ] Tool calling comprovado no modelo candidato, se necessário.
+- [ ] `429`, timeout, retries e fallback possuem testes determinísticos.
+- [ ] Nenhum segredo ou conteúdo sensível aparece em logs.
+- [ ] Rollback por feature flag foi testado.
+
+## Status transition
+
+Esta ADR permanece **Proposed**. Ela pode virar **Accepted** somente após decisão de Pedro e conclusão das gates. Uma futura decisão de produção exige ADR separada.

--- a/docs/adr/ADR-0042-nvidia-nim-experimental-provider.md
+++ b/docs/adr/ADR-0042-nvidia-nim-experimental-provider.md
@@ -1,4 +1,4 @@
-# ADR-0042 — NVIDIA NIM somente como provider experimental
+# ADR-0042 — NVIDIA NIM como provider BYOK para execução restrita
 
 - **Status:** Proposed
 - **Date:** 2026-07-11
@@ -8,44 +8,131 @@
 
 ## Context
 
-O Ouroboros precisa avaliar se endpoints da NVIDIA podem complementar os providers atuais. O runtime, porém, não possui um contrato único em uso: Groq, Z.AI, Gemini, Antigravity e Ollama são chamados por integrações diferentes, com semânticas distintas de timeout, retries, tools, JSON, configuração, métricas e fallback.
+O Ouroboros não busca ser o agente mais rápido. Seu objetivo é permanecer útil em condições adversas: pouca quota, hardware modesto, providers gratuitos, interrupções, indisponibilidade e orçamento baixo.
 
-Os endpoints hospedados do NVIDIA API Catalog/NIM usam um formato compatível com Chat Completions da OpenAI, mas as capacidades variam por modelo. A oferta gratuita do NVIDIA Developer Program é destinada a prototipagem, pesquisa, desenvolvimento e testes, não a produção. Quotas públicas estáveis, residência regional e retenção específica não foram confirmadas.
+A NVIDIA Build/NIM oferece um catálogo amplo de modelos sob chaves gratuitas de desenvolvimento. O limite padrão operacional observado para essas chaves em 2026 é 40 RPM. Esse teto é baixo para workflows multiagentes paralelos, mas é suficiente para um runtime que serialize chamadas, persista estado, espere quota e continue durante longos períodos.
 
-Adicionar NVIDIA diretamente a uma integração existente ou trocar apenas a URL criaria acoplamento e compatibilidade ilusória.
+A arquitetura pretendida é BYOK: cada usuário fornece sua própria chave. O Ouroboros não distribui nem compartilha uma chave central do mantenedor. Portanto, quotas, cooldowns, circuit breakers e métricas precisam ser isolados por credencial do usuário.
+
+O runtime atual possui integrações paralelas para Groq, Z.AI, Gemini, Antigravity e Ollama, sem contrato remoto único nem scheduler durável orientado por quota.
 
 ## Decision
 
-O Ouroboros **não adotará NVIDIA NIM como provider principal ou default neste ciclo**.
+O Ouroboros adotará NVIDIA NIM como **provider opcional BYOK**, inicialmente experimental e desligado até que suas dependências sejam implementadas e verificadas.
 
-Será permitido, após aprovação explícita e conclusão das dependências, um provider experimental com estas restrições:
+A decisão segue estas regras:
 
-1. `nvidia-nim` será opcional, desligado por padrão e ativado por feature flag.
-2. A integração hospedada será limitada a protótipos e tarefas não sensíveis.
-3. Nenhum código privado, segredo, dado pessoal, dado acadêmico confidencial ou conteúdo marcado como sensível será enviado.
-4. Um contrato mínimo de provider será definido antes do adapter NVIDIA.
-5. Capacidades serão declaradas por modelo; “OpenAI-compatible” não implicará tools, JSON Schema, embeddings ou multimodalidade.
-6. O provider atual permanecerá como primário e rollback.
-7. Nenhum limite de 40 RPM será codificado sem evidência oficial ou observada e registrada.
-8. Rate limits serão configuráveis por provider, modelo e operação.
-9. Retries serão restritos a falhas transitórias, com backoff exponencial, full jitter e respeito a `Retry-After`.
-10. O adapter propagará `AbortSignal`, distinguirá timeout de cancelamento e não registrará conteúdo ou credenciais.
-11. Produção exigirá nova ADR, aprovação de custo/licença, revisão de termos, região, retenção e SLA.
+1. Cada usuário ou workspace fornece sua própria `NVIDIA_API_KEY`.
+2. Nenhuma chave do mantenedor será compartilhada, embutida ou usada como quota comum.
+3. A chave bruta não será escrita em repositório, fila, SQLite, logs, eventos, traces ou métricas.
+4. A configuração referenciará uma `credentialRef` e um `credentialScope` opaco.
+5. O perfil gratuito NVIDIA usará 40 RPM como baseline conservador por credencial.
+6. A cadência nominal será 36 RPM, preservando margem para variação de janela e overhead.
+7. O modo restrito usará `maxConcurrency = 1` por credencial por padrão.
+8. `429` e `Retry-After` prevalecem sobre o default e atualizam o cooldown persistido.
+9. Espera por quota será estado normal da tarefa, não falha terminal.
+10. O scheduler persistirá checkpoints, tentativas, `nextEligibleAt` e próxima ação.
+11. Reiniciar o daemon não apagará fila, cooldown ou progresso validado.
+12. Capacidades serão declaradas por `provider + model`; compatibilidade OpenAI não implicará tools ou JSON Schema.
+13. O usuário poderá escolher NVIDIA como provider disponível, sem torná-la provider universal ou obrigatório.
+14. Tarefas sensíveis continuarão sujeitas aos termos e à política de dados do endpoint escolhido.
+15. Produção comercial com garantias exigirá decisão separada sobre licença, custo, região, retenção e SLA.
+
+## Product priority
+
+A prioridade arquitetural é:
+
+```text
+continuidade > aproveitamento da quota > qualidade verificável > latência
+```
+
+O sistema pode levar horas ou dias para completar uma tarefa. Isso é aceitável quando há:
+
+- progresso persistido;
+- pausa e retomada;
+- motivo de espera observável;
+- deduplicação;
+- orçamento finito;
+- validação antes de promoção;
+- cancelamento controlado.
+
+## Credential and quota scope
+
+O limiter superior será chaveado por:
+
+```text
+providerId + credentialScope
+```
+
+Buckets subordinados podem usar:
+
+```text
+providerId + credentialScope + modelId + operation
+```
+
+Para o perfil `nvidia-free`, o bucket superior começa com:
+
+```text
+limit: 40 requests
+window: 60 seconds
+nominalTarget: 36 requests/minute
+maxConcurrency: 1
+burst: 1
+```
+
+O valor é configurável. Não é autorização para ignorar headers, `429` ou mudanças futuras.
+
+`credentialScope` não contém a chave. Deve ser um identificador opaco, preferencialmente derivado por hash com salt local, usado apenas para isolamento de estado e métricas.
+
+## Durable constrained execution
+
+A fila/scheduler precisa suportar:
+
+- `pending`
+- `ready`
+- `running`
+- `waiting_for_quota`
+- `waiting_for_provider`
+- `waiting_for_budget`
+- `waiting_for_human`
+- `completed`
+- `failed_terminal`
+- `cancelled`
+
+Cada passo persiste:
+
+- `taskId` e `stepId`;
+- provider e modelo selecionados;
+- `credentialScope` opaco;
+- tentativas e último erro tipado;
+- `nextEligibleAt`;
+- checkpoint validado;
+- próxima ação;
+- orçamento restante.
+
+Timeout de request não encerra automaticamente a tarefa inteira. A política pode reagendar o passo, usar fallback permitido ou aguardar o provider.
 
 ## Minimal provider boundary
 
-O contrato comum deverá normalizar somente o necessário aos fluxos existentes:
+```ts
+interface ModelProvider {
+  readonly id: string;
+  capabilities(modelId: string): ModelCapabilities;
+  chat(request: ChatRequest, context: ProviderCallContext): Promise<ChatResult>;
+  stream?(request: ChatRequest, context: ProviderCallContext): AsyncIterable<ChatChunk>;
+}
 
-- chat não streaming;
-- streaming opcional;
-- tool calls opcionais;
-- usage e finish reason;
-- timeout e cancelamento;
-- status/headers permitidos;
-- erros tipados e retry hints;
-- capability profile por modelo.
+interface ProviderCallContext {
+  credentialRef: string;
+  credentialScope: string;
+  taskId: string;
+  stepId: string;
+  signal?: AbortSignal;
+  deadlineAt?: string;
+}
+```
 
-Embeddings, reranking, visão e execução de agentes externos não serão forçados no mesmo contrato de chat. Poderão usar portas específicas.
+O contrato comum cobre chat, streaming opcional, tool calls opcionais, usage, finish reason, timeout, cancelamento e erros. Embeddings, reranking, visão e agentes externos permanecem em portas específicas.
 
 ## Error policy
 
@@ -62,83 +149,116 @@ Taxonomia mínima:
 - `provider_error`
 - `malformed_response`
 
-`network_error` representa falhas locais anteriores a uma resposta HTTP, como DNS, conexão recusada ou queda de socket. Ele não deve ser confundido com `unavailable`, normalmente associado a uma resposta transitória do serviço, nem com `provider_error`.
+Cada erro informa:
 
-Cada erro deverá indicar `retryable`, `retryAfterMs` quando conhecido e `fallbackAllowed`.
+- `retryable`;
+- `retryAfterMs`;
+- `fallbackAllowed`;
+- `credentialScope` opaco;
+- se a credencial, o modelo ou o provider deve ser temporariamente bloqueado.
+
+## Efficiency policy
+
+Para extrair valor de recursos escassos:
+
+- preparar contexto localmente antes da chamada;
+- serializar chamadas remotas no perfil restrito;
+- deduplicar instruções e subtarefas;
+- cachear resultados reutilizáveis;
+- executar testes, lint, parsing e transformações determinísticas localmente;
+- usar modelos locais para tarefas simples quando possível;
+- reservar chamadas remotas fortes para planejamento, síntese e correções difíceis;
+- limitar loops de reflexão/revisão por orçamento;
+- fazer checkpoint antes e depois de chamadas externas;
+- pausar em vez de descartar progresso.
 
 ## Rollout
 
-1. Criar contrato e testes com transport fake.
-2. Adaptar um provider existente sem alterar comportamento externo.
-3. Executar POC NVIDIA isolada com chave fornecida por ambiente.
-4. Registrar capacidades e limites observados.
-5. Implementar adapter experimental somente se a POC passar.
-6. Liberar para allowlist de tarefas não sensíveis.
-7. Avaliar dados de erro, latência, throttling e qualidade antes de qualquer ampliação.
+1. Definir contrato comum com `credentialRef` e `credentialScope`.
+2. Centralizar BYOK, secret resolution e redaction.
+3. Implementar limiter e scheduler durável para quota baixa.
+4. Adaptar um provider existente para provar o contrato.
+5. Executar POC NVIDIA isolada com chave do próprio usuário.
+6. Validar chat, streaming, cancelamento, 40 RPM, `429`, cooldown e retomada.
+7. Implementar adapter NVIDIA opcional.
+8. Integrar seleção por capacidade/configuração.
+9. Medir tarefas concluídas por quota, não apenas latência.
 
 ## Rollback
 
-- desligar a feature flag;
-- remover o modelo da allowlist;
-- rotear para o provider anterior;
-- não migrar nem persistir estado específico da NVIDIA;
-- remover o adapter sem alterar memória, sessões ou formatos públicos.
+- remover NVIDIA da configuração do usuário;
+- desligar a feature flag durante a fase experimental;
+- manter fila e checkpoints independentes do provider;
+- selecionar outro provider disponível;
+- não migrar estado para formato proprietário da NVIDIA;
+- remover o adapter sem perder histórico de tarefa.
 
 ## Consequences
 
 ### Positive
 
-- reduz lock-in;
-- impede que diferenças entre modelos virem falhas silenciosas;
-- torna resiliência e observabilidade reutilizáveis;
-- permite obter evidência real sem comprometer o runtime principal;
-- mantém caminho de rollback imediato.
+- cada usuário utiliza sua própria quota;
+- nenhuma chave central vira gargalo ou custo do mantenedor;
+- 40 RPM se torna restrição administrável em vez de falha constante;
+- tarefas sobrevivem a reinícios e longos cooldowns;
+- a arquitetura melhora também Groq, Z.AI, Gemini e outros providers;
+- o sistema é coerente com a visão de construir bem usando recursos limitados.
 
 ### Negative
 
-- exige trabalho arquitetural antes da POC integrada;
-- adiciona capability profiles e taxonomia de erros;
-- não explora imediatamente todos os modelos do catálogo;
-- o endpoint gratuito não pode atender fluxos sensíveis ou de produção.
+- tarefas podem demorar muito;
+- exige persistência mais rica que a fila atual;
+- requer UX clara para estados de espera;
+- BYOK transfere ao usuário a responsabilidade por termos, quota e validade da chave;
+- capability profiles e isolamento por credencial aumentam a complexidade interna.
 
 ### Risks
 
-- o catálogo, modelos ou termos podem mudar;
-- quotas podem variar por conta/modelo;
-- comportamento observado pode divergir da documentação;
-- um adapter OpenAI-style pode esconder parâmetros incompatíveis;
-- fallback automático pode elevar custo ou mascarar falhas sem limites claros.
+- 40 RPM pode mudar por conta, modelo ou tráfego;
+- cooldown incorreto pode desperdiçar tempo ou gerar novos `429`;
+- persistência insegura poderia vazar credenciais;
+- fallback mal configurado poderia consumir outra chave sem autorização;
+- loops longos poderiam desperdiçar quota lentamente sem gates de valor;
+- termos do endpoint gratuito podem mudar.
 
 ## Rejected alternatives
 
-### NVIDIA como provider principal
+### Chave NVIDIA única do projeto
 
-Rejeitada por restrições de produção, ausência de SLA gratuito, quotas não confirmadas, risco de dados e fragmentação interna.
+Rejeitada. Criaria gargalo global, custo, risco de abuso e mistura de quotas entre usuários.
 
-### Trocar `baseUrl` do DirectZAIProvider
+### Otimizar para paralelismo máximo
 
-Rejeitada porque o loop depende de tool calling e formatos Z.AI; capacidades NVIDIA são por modelo e não equivalentes.
+Rejeitada. Não corresponde ao objetivo do produto e colide com quotas gratuitas.
 
-### Criar abstração universal para todos os tipos de IA
+### Tratar `429` como falha definitiva
 
-Rejeitada por excesso de generalização. Chat, embeddings, reranking e agentes externos possuem contratos diferentes.
+Rejeitada. No modo restrito, quota esgotada normalmente significa reagendar e continuar depois.
 
-### Não investigar NVIDIA
+### Trocar apenas o `baseUrl` do DirectZAIProvider
 
-Rejeitada porque uma POC isolada pode produzir evidência útil com baixo risco após as dependências.
+Rejeitada. Capacidades, credenciais, quota e respostas variam por provider/modelo.
 
-## Acceptance gates before implementation
+### Abstração universal para toda IA
 
-- [ ] Pedro aprova o experimento e qualquer risco/custo.
-- [ ] Baseline da #34 permite nova integração.
-- [ ] Contrato mínimo e capability profiles aprovados.
-- [ ] Configuração e segredo centralizados.
-- [ ] POC não integrada comprova autenticação, chat, streaming e cancelamento.
-- [ ] Tool calling comprovado no modelo candidato, se necessário.
-- [ ] `429`, timeout, retries e fallback possuem testes determinísticos.
-- [ ] Nenhum segredo ou conteúdo sensível aparece em logs.
-- [ ] Rollback por feature flag foi testado.
+Rejeitada. Chat, embeddings, reranking, visão e execução de agentes possuem contratos diferentes.
+
+## Acceptance gates
+
+- [ ] contrato suporta `credentialRef` e `credentialScope`;
+- [ ] nenhuma chave bruta é persistida fora de secret store aprovado;
+- [ ] limiter isola cada credencial;
+- [ ] perfil `nvidia-free` usa baseline 40 RPM e alvo nominal 36 RPM;
+- [ ] `429` persiste cooldown e respeita `Retry-After`;
+- [ ] fila restaura `waiting_for_quota` após reinício;
+- [ ] concorrência 1 evita rajadas no modo restrito;
+- [ ] POC real usa chave fornecida pelo próprio usuário;
+- [ ] logs e métricas não revelam chave, prompt ou resposta integral;
+- [ ] tarefas podem pausar e retomar sem repetir passos concluídos;
+- [ ] fallback nunca usa credencial de outro usuário;
+- [ ] rollback para outro provider preserva checkpoint e fila;
+- [ ] Pedro aprova a implementação após o baseline da #34 permitir expansão.
 
 ## Status transition
 
-Esta ADR permanece **Proposed**. Ela pode virar **Accepted** somente após decisão de Pedro e conclusão das gates. Uma futura decisão de produção exige ADR separada.
+Esta ADR permanece **Proposed** até que contrato, BYOK, scheduler durável e POC sejam verificados. A decisão de usar NVIDIA em produção comercial continua fora deste ADR.

--- a/docs/adr/ADR-0042-nvidia-nim-experimental-provider.md
+++ b/docs/adr/ADR-0042-nvidia-nim-experimental-provider.md
@@ -57,9 +57,12 @@ Taxonomia mínima:
 - `rate_limited`
 - `timeout`
 - `cancelled`
+- `network_error`
 - `unavailable`
 - `provider_error`
 - `malformed_response`
+
+`network_error` representa falhas locais anteriores a uma resposta HTTP, como DNS, conexão recusada ou queda de socket. Ele não deve ser confundido com `unavailable`, normalmente associado a uma resposta transitória do serviço, nem com `provider_error`.
 
 Cada erro deverá indicar `retryable`, `retryAfterMs` quando conhecido e `fallbackAllowed`.
 

--- a/docs/research/nvidia-nim-provider-evaluation-2026-07-11.md
+++ b/docs/research/nvidia-nim-provider-evaluation-2026-07-11.md
@@ -115,7 +115,7 @@ Portanto:
 |---|---:|---|
 | `401`/`403` | Não | falhar como `authentication`/`authorization`; nunca trocar chave automaticamente |
 | `400`/`422` | Não | falhar como `invalid_request`; corrigir payload/capability profile |
-| `408`, rede transitória | Sim | backoff exponencial com full jitter e limite de tentativas |
+| `408`, rede transitória | Sim | falhar como `network_error` quando não houver resposta HTTP; backoff exponencial com full jitter e limite de tentativas |
 | `429` | Sim, controlado | honrar `Retry-After`; não multiplicar carga; abrir circuito se recorrente |
 | `5xx` transitório | Sim | backoff+jitter; fallback após orçamento de tentativas |
 | timeout/cancelamento | Não automaticamente | distinguir timeout de cancelamento do usuário; propagar `AbortSignal` |
@@ -211,9 +211,11 @@ Elementos obrigatórios do contrato normalizado:
 - timeout externo e `AbortSignal` propagável;
 - conteúdo, tool calls, finish reason e usage;
 - status HTTP e headers permitidos para diagnóstico, sem segredo;
-- taxonomia: `authentication`, `authorization`, `invalid_request`, `rate_limited`, `timeout`, `cancelled`, `unavailable`, `provider_error`, `malformed_response`;
+- taxonomia: `authentication`, `authorization`, `invalid_request`, `rate_limited`, `timeout`, `cancelled`, `network_error`, `unavailable`, `provider_error`, `malformed_response`;
 - `retryable`, `retryAfterMs` e `fallbackAllowed` explícitos;
 - validação de resposta antes de entregar a gates críticos.
+
+`network_error` cobre falhas locais anteriores a qualquer resposta HTTP, como DNS, conexão recusada e queda de socket. Ele é diferente de indisponibilidade HTTP e de erro interno do provider.
 
 Perfis de modelo devem declarar capacidades, não inferi-las do nome do provider:
 
@@ -285,6 +287,7 @@ Só liberar além de experimento após Pedro aprovar:
 ### Falhas
 
 - `401`, `403`, `422`, `429`, `500`, `503`;
+- DNS, conexão recusada e queda de socket classificados como `network_error`;
 - rede desconectada;
 - timeout;
 - cancelamento pelo chamador;

--- a/docs/research/nvidia-nim-provider-evaluation-2026-07-11.md
+++ b/docs/research/nvidia-nim-provider-evaluation-2026-07-11.md
@@ -1,372 +1,312 @@
-# Avaliação da NVIDIA NIM como provider do Ouroboros
+# Avaliação da NVIDIA NIM como provider BYOK do Ouroboros
 
 - **Issue:** #42
 - **Parent:** #34
-- **Data de verificação:** 2026-07-11
+- **Data de verificação inicial:** 2026-07-11
+- **Revisão de visão:** 2026-07-11, após alinhamento com Pedro
 - **Natureza:** pesquisa arquitetural; nenhuma integração de produção foi implementada
-- **Resultado recomendado:** **experimentar de forma opcional e reversível**, nunca como provider principal neste ciclo
+- **Resultado recomendado:** adotar NVIDIA NIM como provider opcional BYOK, desenhado para execução lenta, durável e consciente de quota
 
 ## 1. Resumo executivo
 
-O produto analisado é o conjunto de **endpoints hospedados do NVIDIA API Catalog/NIM**, acessível por API compatível com o formato de Chat Completions da OpenAI em `https://integrate.api.nvidia.com/v1/chat/completions`. O NIM auto-hospedado é uma alternativa distinta, baseada em containers e infraestrutura NVIDIA.
+O produto analisado é o conjunto de endpoints hospedados do NVIDIA API Catalog/NIM, acessível por API no formato OpenAI Chat Completions em `https://integrate.api.nvidia.com/v1/chat/completions`.
 
-A oferta hospedada é adequada para protótipos, pesquisa, desenvolvimento e testes. A documentação oficial afirma que o acesso do NVIDIA Developer Program não é destinado a produção e não inclui estabilidade ou suporte empresarial. Uso real por usuários finais exige NVIDIA AI Enterprise. Por isso, a oferta hospedada gratuita não pode ser tratada como infraestrutura principal do Ouroboros.
+A visão do Ouroboros não é construir o agente mais rápido. O objetivo é construir um agente que continue trabalhando sob condições ruins: pouca quota, modelos gratuitos, hardware modesto, interrupções, indisponibilidade e orçamento quase nulo. Latência é secundária; continuidade, qualidade acumulada e capacidade de retomar são prioritárias.
 
-A hipótese de **40 requisições por minuto** não foi confirmada nas fontes oficiais consultadas. Não foi encontrada uma tabela pública estável de quota, granularidade, headers ou política por modelo/conta. O número não deve ser hardcoded.
+A NVIDIA é especialmente relevante para esse objetivo porque fornece uma variedade grande de modelos sob uma chave gratuita de desenvolvimento, mesmo com quota baixa. O limite padrão observado para chaves gratuitas é **40 RPM por chave**. Fóruns da NVIDIA registram repetidamente contas com esse limite e pedidos de aumento. Há também orientação de que a camada gratuita é para prototipagem e não recebe aumento manual pelo fórum.
 
-A compatibilidade com OpenAI é parcial e varia por modelo. Streaming SSE aparece nos modelos inspecionados, mas `tools` foi documentado para Qwen3 Coder e não apareceu nos contratos consultados de GLM4.7 e Nemotron 3 Nano. `response_format`/JSON Schema também não foi documentado nesses três contratos. Logo, o Ouroboros precisa de perfis de capacidade por modelo, não de uma flag genérica “OpenAI-compatible”.
+O número de 40 RPM deve ser usado como **baseline operacional conservador**, mas não como garantia contratual eterna. O cliente deve continuar configurável e reagir a `429`, `Retry-After`, mudanças por modelo e alterações futuras da plataforma.
 
-O principal bloqueio atual é interno: o runtime possui integrações paralelas e fortemente acopladas para Groq, Z.AI, Gemini, Antigravity e Ollama. Há uma interface `ILLMProvider`, mas ela não governa os providers usados pelo CLI atual. Integrar a NVIDIA diretamente aumentaria a fragmentação.
+A arquitetura correta não é compartilhar uma única chave do mantenedor entre todos os usuários. Cada usuário informa sua própria chave — modelo BYOK, _bring your own key_. Consequentemente, quota, cooldown, métricas e circuit breaker devem ser isolados por credencial do usuário, nunca tratados como uma quota global do Ouroboros.
 
-### Decisão proposta
+## 2. Princípio de produto: continuidade acima de velocidade
 
-1. Não substituir Groq, Z.AI, Gemini ou Ollama pela NVIDIA agora.
-2. Consolidar primeiro um contrato mínimo e uma taxonomia comum de erros/capacidades.
-3. Criar depois uma prova de conceito isolada do endpoint hospedado, sem dados sensíveis e sem custo não aprovado.
-4. Somente após a prova, considerar um adapter `nvidia-nim` atrás de feature flag, desligado por padrão.
-5. Manter o provider existente como caminho primário e rollback imediato.
-6. Reabrir a decisão de produção apenas com licença, custos, regiões, retenção e SLA documentados.
+O Ouroboros deve otimizar para:
 
-## 2. Produto e contrato oficial
+1. **trabalho concluído por quota disponível**, não requisições por segundo;
+2. **progresso persistente**, não sessões rápidas e descartáveis;
+3. **serialização segura**, não paralelismo agressivo;
+4. **retomada após horas ou dias**, não timeout global curto;
+5. **degradação controlada**, não falha total quando um provider acaba;
+6. **qualidade acumulada**, usando planejamento, execução, teste e revisão em etapas espaçadas;
+7. **infraestrutura do usuário**, sem subsidiar todos com uma chave central.
 
-### 2.1 Produto considerado
+Uma tarefa pode levar horas. Isso não é falha, desde que:
 
-| Opção | Natureza | Uso apropriado | Conclusão para o Ouroboros |
-|---|---|---|---|
-| NVIDIA API Catalog / NIM hosted endpoints | Inferência hospedada pela NVIDIA, chave de desenvolvedor, APIs por modelo | Protótipos, pesquisa, desenvolvimento e testes | Candidato apenas experimental |
-| NIM auto-hospedado | Containers de inferência executados em infraestrutura NVIDIA | Controle de dados e operação própria | Fora do ciclo atual; exige GPU/infraestrutura e avaliação de licença |
-| NVIDIA AI Enterprise | Licença e suporte empresarial para produção | Produção, estabilidade e suporte | Só considerar mediante decisão explícita de custo |
+- o estado esteja persistido;
+- o próximo passo seja conhecido;
+- o usuário consiga pausar, retomar e cancelar;
+- a fila não repita trabalho já concluído;
+- os limites e motivos de espera estejam visíveis;
+- o resultado passe por validação antes de promoção.
 
-A FAQ oficial apresenta o catálogo como ambiente para construir POCs e recomenda migrar para compute próprio após o protótipo. Também diferencia o Developer Program, destinado a prototipagem, do NVIDIA AI Enterprise, exigido para produção.
+## 3. Produto, uso e limitações
 
-### 2.2 Autenticação e endpoint
+| Opção | Natureza | Adequação ao Ouroboros |
+|---|---|---|
+| NVIDIA Build / NIM hosted | Endpoints hospedados, chave de desenvolvedor e catálogo amplo | Boa opção BYOK para execução restrita e prototipagem pessoal |
+| NIM auto-hospedado | Containers executados em hardware do usuário | Alternativa futura para usuários com GPU/infraestrutura compatível |
+| NVIDIA AI Enterprise | Licença e suporte comercial | Fora do objetivo gratuito inicial; avaliar apenas quando houver demanda real |
 
-- Autenticação: token Bearer.
-- Endpoint de chat hospedado observado: `POST https://integrate.api.nvidia.com/v1/chat/completions`.
-- Formato: descrito como compatível com Chat Completions da OpenAI.
-- O catálogo também expõe APIs distintas para embeddings, reranking, visão e outros domínios; não se deve presumir um contrato único.
+A oferta gratuita não deve ser apresentada como SLA de produção. O Ouroboros pode, porém, ser deliberadamente útil em ambientes pessoais e de desenvolvimento sem fingir que o endpoint possui garantias empresariais.
 
-### 2.3 Gratuidade, créditos e produção
+## 4. Limite de 40 RPM
 
-**Confirmado:** membros do NVIDIA Developer Program possuem acesso gratuito a endpoints NIM para prototipagem e a NIMs auto-hospedáveis para pesquisa/desenvolvimento/experimentação, dentro das condições do programa.
+### 4.1 Estado da premissa
 
-**Confirmado:** o programa gratuito não é uma licença de produção. A FAQ define produção como atividade além de desenvolvimento, teste, pesquisa ou avaliação, incluindo servir usuários reais.
+A premissa foi atualizada para:
 
-**Confirmado:** a documentação consultada informa que NVIDIA AI Enterprise começa em aproximadamente USD 4.500 por GPU/ano ou cerca de USD 1 por GPU/hora na nuvem. Esses números são referência do licenciamento de produção, não preço por requisição do endpoint de desenvolvimento.
+> **40 RPM é o limite padrão operacional observado para chaves gratuitas NVIDIA Build/NIM em 2026.**
 
-**Risco:** os termos permitem encerrar promoções gratuitas/descontadas, aplicar cobranças padrão após o fim da promoção ou após exceder seus termos, e alterar/depreciar tecnologia sem aviso prévio.
+Evidências operacionais:
 
-### 2.4 Dados, privacidade e segurança
+- tópico de junho de 2026 registra `Current limit: 40 RPM` e resposta descrevendo o teto gratuito como limite rígido do sandbox;
+- múltiplos pedidos de aumento de `40 → 200 RPM` relatam o mesmo limite;
+- moderação informa que não há aumento de quota pela camada gratuita e que os limites podem depender de modelo, uso e tráfego.
 
-Os Termos de Acesso à Tecnologia concedem à NVIDIA, afiliadas e prestadores uma licença sobre conteúdo enviado para operar, dar suporte, proteger e melhorar produtos/serviços. Salvo acordo de produto em contrário, os termos também proíbem o envio de informação confidencial, dados pessoais/controlados/sensíveis e outras categorias protegidas.
+Portanto, a implementação deve:
 
-Consequências para o Ouroboros hospedado:
-
-- não enviar código privado, segredos, dados pessoais ou conteúdo acadêmico/confidencial;
-- aplicar redaction antes da requisição;
-- nunca registrar chave, header Authorization, prompt integral ou resposta sensível;
-- considerar retenção, residência regional e prazo de exclusão como **desconhecidos** até existir documento específico do produto/conta;
-- tratar o endpoint gratuito como ambiente externo de desenvolvimento, não como boundary confiável de produção.
-
-## 3. Modelos e capacidades observadas
-
-A lista do catálogo é dinâmica. A tabela abaixo registra somente o contrato oficial consultado em 2026-07-11, não uma garantia permanente.
-
-| Modelo inspecionado | Chat OpenAI-style | Streaming | Tool calling documentado | Structured output documentado | `max_tokens` de saída documentado |
-|---|---:|---:|---:|---:|---:|
-| `z-ai/glm4.7` | Sim | Sim, SSE | Não localizado no contrato consultado | Não localizado | 1–32768 |
-| `qwen/qwen3-coder-480b-a35b-instruct` | Sim | Sim, SSE | Sim, campo `tools` | Não localizado | 1–16384 |
-| `nvidia/nemotron-3-nano-30b-a3b` | Sim | Sim, SSE | Não localizado no contrato consultado | Não localizado | 1–32768 |
-
-Observações:
-
-- “Não localizado” não significa que o modelo nunca suporte a capacidade; significa que ela não deve ser assumida sem prova e contrato oficial atual.
-- `max_tokens` é limite de geração documentado, não prova do contexto total.
-- Os defaults variam por modelo, inclusive `stream`; o adapter deve enviar valores explícitos.
-- O endpoint pode devolver `202` em algumas operações/modelos, portanto o contrato normalizado precisa admitir execução assíncrona ou rejeitá-la explicitamente.
-- A ausência de `response_format` nos contratos analisados impede chamar JSON por prompt de “structured output garantido”.
-
-## 4. Limites operacionais
-
-### 4.1 Hipótese de 40 RPM
-
-**Resultado:** não confirmada.
-
-Nas páginas oficiais consultadas não foi encontrada uma tabela pública que estabeleça 40 RPM como limite geral ou específico do Ouroboros. Também não foi localizado contrato público estável para:
-
-- quota por conta, chave, modelo ou endpoint;
-- requests/minuto e tokens/minuto;
-- concorrência;
-- headers de limite;
-- janela de reset;
-- comportamento formal de `429`.
-
-Portanto:
-
-- não codificar `40` como constante;
-- tornar limites configuráveis por `provider + model + operation`;
-- capturar, sem conteúdo sensível, status e headers de resposta observados na POC;
+- usar `40 RPM` como default do perfil `nvidia-free`;
+- mirar **36 RPM** por padrão, equivalente a aproximadamente uma chamada a cada 1,67 segundo, preservando margem;
+- usar `maxConcurrency = 1` por credencial no modo restrito;
+- permitir override explícito quando a conta tiver outro contrato;
+- reduzir dinamicamente a cadência após `429`;
 - respeitar `Retry-After` quando presente;
-- classificar `429` como defesa genérica de gateway, sem alegar que é contrato NVIDIA confirmado.
+- persistir `nextEligibleAt`, para que reiniciar o daemon não apague o cooldown;
+- nunca executar load test para descobrir quota.
 
-### 4.2 Política de resiliência proposta
+### 4.2 Escopo da quota
 
-| Evento | Retry? | Política |
-|---|---:|---|
-| `401`/`403` | Não | falhar como `authentication`/`authorization`; nunca trocar chave automaticamente |
-| `400`/`422` | Não | falhar como `invalid_request`; corrigir payload/capability profile |
-| `408`, rede transitória | Sim | falhar como `network_error` quando não houver resposta HTTP; backoff exponencial com full jitter e limite de tentativas |
-| `429` | Sim, controlado | honrar `Retry-After`; não multiplicar carga; abrir circuito se recorrente |
-| `5xx` transitório | Sim | backoff+jitter; fallback após orçamento de tentativas |
-| timeout/cancelamento | Não automaticamente | distinguir timeout de cancelamento do usuário; propagar `AbortSignal` |
+O limiter deve ser chaveado, no mínimo, por:
 
-Circuit breaker recomendado: chaveado por `providerId + modelId + operation`. Um estado local em memória é suficiente enquanto houver um único daemon. Só adotar estado distribuído quando houver múltiplos processos/instâncias concorrentes.
+```text
+providerId + credentialScope
+```
 
-## 5. Inventário da arquitetura atual
+E pode possuir buckets subordinados por:
 
-### 5.1 Chamadas diretas e acoplamentos
+```text
+providerId + credentialScope + modelId + operation
+```
 
-| Área | Arquivo | Provider/contrato atual | Riscos relevantes |
-|---|---|---|---|
-| Classificação de intenção | `cli/src/concierge/ConciergeClient.ts` | `groq-sdk`, modelo hardcoded | sem contrato compartilhado; fallback genérico; `console.error` |
-| Agente com tools | `cli/src/providers/direct-zai.ts` | HTTP OpenAI-style da Z.AI | modelo/base URL hardcoded; sem retry/rate limit/circuit breaker |
-| Loop de agente | `cli/src/providers/agent-loop.ts` | depende concretamente de `DirectZAIProvider` | não permite substituir provider sem refatorar o loop |
-| Review multi-modelo | `cli/src/orchestration/strategies/MultiModelReviewStrategy.ts` | fetch direto OpenAI-style | default de modelo Gemini combinado com endpoint Z.AI; falha pode virar heurística silenciosa; já coberto parcialmente por #36 |
-| Gemini | `cli/src/runtime/GeminiDirectAPI.ts` | REST específica do Google | tipos/modelos hardcoded; chave em query string; sem retry/rate limit |
-| Delegação daemon | `cli/src/daemon/rpc-gateway.ts` | roteamento por strings `gemini`, `glm`, `jules`, `antigravity` | Z.AI acoplada a wave/parser; carregamento de segredo fragmentado |
-| Inferência local | `cli/src/inference/LocalInferenceProvider.ts` | Ollama HTTP | retries e métricas locais, mas contrato exclusivo de Ollama |
-| Registry/router local | `cli/src/inference/ModelRegistry.ts`, `ModelRouter.ts`, `InferenceSubsystem.ts` | `LocalInferenceProvider` e `ollamaModel` | capacidades/roteamento não incluem dimensão de provider remoto |
-| Porta conceitual | `src/core/ports/ILLMProvider.ts` | interface mínima `chat()` | não governa os providers ativos do CLI; insuficiente para streaming, abort, usage e erros |
-| Configuração | `cli/src/utils/env-loader.ts`, `.env.example` | Groq/Google como obrigatórios | ausência de registry central de credenciais/providers; Z.AI carregada em outros pontos |
+`credentialScope` é um identificador interno opaco da chave do usuário. Não é a chave, não contém prefixo suficiente para reconstruí-la e pode ser derivado por hash com salt local.
 
-### 5.2 Achados críticos
+A regra conservadora para NVIDIA gratuita é um bucket superior de 40 RPM por credencial, mesmo quando modelos diferentes forem usados. Perfis inferiores podem ficar mais restritivos quando a POC ou headers indicarem limites por modelo/operação.
 
-1. Existem ao menos três arquiteturas de inferência em paralelo: core/ports, CLI providers remotos e subsistema local/Ollama.
-2. Compatibilidade OpenAI é usada como detalhe de transporte, mas não existe perfil formal de capacidades por modelo.
-3. Timeouts, retries, fallback, métricas e segredo são implementados de formas diferentes em cada integração.
-4. O `ModelRouter` possui circuit breaker e fallback somente no domínio de modelos locais e não controla Z.AI/Groq/Gemini.
-5. O `MultiModelReviewStrategy` já possui uma incoerência provider/model e deve ser corrigido pela #36, sem ampliar aquela issue para NVIDIA.
-6. Integrar NVIDIA diretamente em `direct-zai.ts` ou trocar apenas `baseUrl` criaria compatibilidade aparente e falhas silenciosas em tools, JSON e defaults.
+## 5. BYOK: cada usuário usa a própria chave
 
-## 6. Compatibilidade com os fluxos do Ouroboros
+### 5.1 Decisão
 
-| Necessidade atual | NVIDIA hosted | Situação |
+O Ouroboros não fornecerá uma chave NVIDIA compartilhada para todos os usuários.
+
+Cada usuário ou workspace configura sua própria credencial. Isso significa:
+
+- a quota de um usuário não consome a quota de outro;
+- erros `401`, `403` e `429` são atribuídos ao escopo correto;
+- métricas são separadas por identificador opaco de credencial;
+- fallback não pode trocar silenciosamente para a chave de outra pessoa;
+- nenhuma chave do mantenedor é distribuída no código, instalador, frontend ou documentação.
+
+### 5.2 Tratamento seguro
+
+A chave bruta:
+
+- nunca entra no repositório;
+- nunca aparece em logs, eventos, traces, métricas ou snapshots;
+- nunca é persistida na fila ou no SQLite de tarefas;
+- deve ficar em variável de ambiente, memória do processo ou secret store seguro;
+- só pode ser persistida quando existir armazenamento de segredo explicitamente projetado para isso;
+- deve ser redigida de mensagens de erro e dumps de request.
+
+A configuração comum referencia `credentialScope`/`credentialRef`, não o valor da chave.
+
+## 6. Capacidades por modelo
+
+A compatibilidade OpenAI é apenas de transporte. Capacidades devem ser declaradas por `provider + model`.
+
+| Modelo inspecionado | Chat | Streaming | Tools documentadas | Structured output garantido |
+|---|---:|---:|---:|---:|
+| `z-ai/glm4.7` | Sim | Sim | Não localizado no contrato consultado | Não localizado |
+| `qwen/qwen3-coder-480b-a35b-instruct` | Sim | Sim | Sim | Não localizado |
+| `nvidia/nemotron-3-nano-30b-a3b` | Sim | Sim | Não localizado no contrato consultado | Não localizado |
+
+“Não localizado” significa que a capacidade não pode ser presumida. JSON solicitado por prompt continua sendo texto não confiável e precisa de validação local conservadora.
+
+## 7. Inventário da arquitetura atual
+
+| Área | Implementação atual | Problema para BYOK durável |
 |---|---|---|
-| Chat simples | Compatível nos modelos analisados | Favorável |
-| Streaming SSE | Documentado | Favorável, requer parser robusto e cancelamento |
-| Tool calling do AgentLoop | Modelo-específico | Qwen3 Coder é candidato; não assumir para GLM/Nemotron |
-| JSON para routing/review | Prompt JSON possível; schema garantido não documentado | Insuficiente para gate crítico sem validação conservadora |
-| Usage/tokens | Resposta OpenAI-style pode fornecer usage, mas deve ser validada por modelo | POC necessária |
-| Embeddings/reranking | Existem APIs específicas no catálogo | Não usar o adapter de chat como abstração universal |
-| AbortSignal/timeout | Implementável no cliente | Favorável |
-| Fallback | Responsabilidade do Ouroboros | Requer contrato e roteador comuns |
-| Custos/orçamento | Oferta de dev não equivale a produção; quota pública não confirmada | Bloqueador para default/produção |
-| Dados confidenciais | Termos gerais não permitem no uso analisado sem acordo específico | Bloqueador para tarefas sensíveis |
+| Concierge | `groq-sdk` direto | modelo e credencial fora de um registry comum |
+| Agente com tools | `DirectZAIProvider` concreto | loop acoplado a um provider |
+| Gemini | REST própria | timeout/configuração específicos |
+| Review | fetch OpenAI-style direto | provider/model incoerentes e fallback silencioso, tratado em #36 |
+| Inferência local | `LocalInferenceProvider`/Ollama | arquitetura separada dos providers remotos |
+| RPC | strings `gemini`, `glm`, `jules`, `antigravity` | seleção não baseada em capacidades/credenciais |
+| Fila | `PriorityTaskQueue` com snapshot JSON | não possui `nextEligibleAt`, espera de quota ou estado `blocked_by_quota` |
+| Scheduler | `EvolutionScheduler` | possui budget e frequência, mas não governa quota por credencial/provider |
+| Porta conceitual | `ILLMProvider` | insuficiente para streaming, usage, abort, erro e escopo de credencial |
 
-## 7. Matriz de alternativas
+O projeto já possui peças úteis — fila persistível, deduplicação, budget, scheduler e circuit breaker — mas elas ainda não formam uma máquina de execução durável orientada por quota.
 
-Escala: 1 = ruim/alto risco; 5 = favorável.
+## 8. Arquitetura alvo
 
-| Alternativa | Custo inicial | Disponibilidade previsível | Complexidade | Lock-in | Segurança de dados | Testabilidade | Nota |
-|---|---:|---:|---:|---:|---:|---:|---|
-| NVIDIA principal | 3 | 1 | 2 | 2 | 1 | 3 | Rejeitar neste ciclo |
-| NVIDIA fallback global | 3 | 2 | 2 | 3 | 2 | 3 | Ainda amplo demais |
-| NVIDIA opcional por configuração | 4 | 3 | 3 | 4 | 3 | 4 | Recomendado após contrato/POC |
-| NVIDIA para tarefa/modelo específico | 4 | 3 | 3 | 4 | 3 | 4 | Melhor primeiro rollout |
-| Não adotar | 5 | 5 | 5 | 5 | 5 | 5 | Seguro, mas perde evidência prática |
-| NIM auto-hospedado agora | 1 | 3 | 1 | 2 | 5 | 3 | Fora do escopo/hardware atual |
-
-## 8. Premissas: confirmadas, rejeitadas e desconhecidas
-
-| Premissa | Estado | Evidência/consequência |
-|---|---|---|
-| “A NVIDIA é gratuita para desenvolvedores” | **Confirmada com qualificação** | gratuita para prototipagem/pesquisa/dev/testes no Developer Program; não é promessa de produção |
-| “O limite é 40 RPM” | **Não confirmada** | não localizada em fonte oficial consultada; proibir hardcode |
-| “É OpenAI-compatible” | **Confirmada parcialmente** | endpoint e formato de chat compatíveis; campos/capacidades variam por modelo |
-| “Todos os modelos têm tools” | **Rejeitada como premissa** | `tools` apareceu no Qwen3 Coder, não nos outros contratos analisados |
-| “JSON estruturado é garantido” | **Não confirmada** | `response_format`/schema não localizado nos três contratos |
-| “Pode substituir providers atuais” | **Rejeitada neste ciclo** | contrato de uso, quotas desconhecidas e fragmentação interna tornam a troca arriscada |
-| “Um limiter único de 40 RPM resolve” | **Rejeitada** | granularidade desconhecida; política deve ser configurável por provider/model/operação |
-| Retenção de prompts/outputs | **Desconhecida** | exigir documento específico antes de dados sensíveis |
-| Data residency/região do endpoint | **Desconhecida** | não assumir residência no Brasil/EUA |
-| SLA do endpoint gratuito | **Ausente para o caso analisado** | Developer Program não oferece estabilidade/suporte empresarial |
-
-## 9. Arquitetura alvo mínima
-
-Evitar uma abstração universal excessiva. O primeiro contrato deve cobrir apenas chat/streaming/tools usados pelo runtime.
+### 8.1 Contrato de provider
 
 ```ts
 interface ModelProvider {
   readonly id: string;
   capabilities(modelId: string): ModelCapabilities;
-  chat(request: ChatRequest, signal?: AbortSignal): Promise<ChatResult>;
-  stream?(request: ChatRequest, signal?: AbortSignal): AsyncIterable<ChatChunk>;
+  chat(request: ChatRequest, context: ProviderCallContext): Promise<ChatResult>;
+  stream?(request: ChatRequest, context: ProviderCallContext): AsyncIterable<ChatChunk>;
+}
+
+interface ProviderCallContext {
+  credentialRef: string;
+  credentialScope: string;
+  signal?: AbortSignal;
+  deadlineAt?: string;
+  taskId: string;
+  stepId: string;
 }
 ```
 
-Elementos obrigatórios do contrato normalizado:
+O contrato deve normalizar chat, streaming opcional, tools opcionais, usage, finish reason, cancelamento e erros. Embeddings, reranking, visão e agentes externos continuam em portas específicas.
 
-- `providerId`, `modelId`, operação e capability profile;
-- mensagens e tools normalizadas;
-- timeout externo e `AbortSignal` propagável;
-- conteúdo, tool calls, finish reason e usage;
-- status HTTP e headers permitidos para diagnóstico, sem segredo;
-- taxonomia: `authentication`, `authorization`, `invalid_request`, `rate_limited`, `timeout`, `cancelled`, `network_error`, `unavailable`, `provider_error`, `malformed_response`;
-- `retryable`, `retryAfterMs` e `fallbackAllowed` explícitos;
-- validação de resposta antes de entregar a gates críticos.
+### 8.2 Taxonomia de erros
 
-`network_error` cobre falhas locais anteriores a qualquer resposta HTTP, como DNS, conexão recusada e queda de socket. Ele é diferente de indisponibilidade HTTP e de erro interno do provider.
+- `authentication`
+- `authorization`
+- `invalid_request`
+- `rate_limited`
+- `timeout`
+- `cancelled`
+- `network_error`
+- `unavailable`
+- `provider_error`
+- `malformed_response`
 
-Perfis de modelo devem declarar capacidades, não inferi-las do nome do provider:
+Cada erro informa `retryable`, `retryAfterMs`, `fallbackAllowed` e o escopo opaco da credencial.
 
-```ts
-interface ModelCapabilities {
-  chat: boolean;
-  streaming: boolean;
-  tools: boolean;
-  structuredOutput: 'none' | 'json_object' | 'json_schema';
-  embeddings: boolean;
-  reranking: boolean;
-  vision: boolean;
-  maxOutputTokens?: number;
-}
+### 8.3 Scheduler restrito
+
+O scheduler precisa tratar espera como estado normal:
+
+```text
+pending
+ready
+running
+waiting_for_quota
+waiting_for_provider
+waiting_for_budget
+waiting_for_human
+completed
+failed_terminal
+cancelled
 ```
 
-## 10. Plano incremental e reversível
+Cada etapa persiste:
 
-### Fase A — contrato e inventário
+- input normalizado ou referência segura;
+- output validado ou hash/referência;
+- número de tentativas;
+- provider/modelo escolhido;
+- `credentialScope` opaco;
+- `nextEligibleAt`;
+- motivo de bloqueio;
+- checkpoint anterior e próxima ação.
 
-- consolidar o contrato mínimo sem mudar o provider padrão;
-- adaptar primeiro um provider existente como prova do contrato;
-- centralizar resolução de configuração e segredo;
-- criar testes de contrato com transport fake.
+Timeout de uma chamada não deve virar timeout da tarefa inteira. A tarefa pode voltar à fila e continuar mais tarde.
 
-### Fase B — POC NVIDIA isolada
+## 9. Estratégias para produzir qualidade com pouca quota
 
-- script/teste não importado pelo runtime principal;
-- chave apenas por `NVIDIA_API_KEY`;
-- modelo selecionado explicitamente;
-- chamada simples e streaming;
-- tool calling apenas em modelo cujo contrato documente `tools`;
-- JSON validado localmente;
-- credencial inválida, timeout, cancelamento e `429` simulado;
-- registrar status/headers de limite observados sem prompt/segredo;
-- nenhuma chamada paga ou teste de carga.
+- concorrência 1 por chave no perfil restrito;
+- agrupar contexto antes de chamar o modelo;
+- usar uma chamada maior e bem preparada em vez de várias chamadas impulsivas;
+- deduplicar subtarefas e perguntas equivalentes;
+- cachear respostas reutilizáveis com invalidação explícita;
+- executar parsing, busca local, testes, lint e transformações determinísticas sem LLM;
+- usar modelo local para classificação, sumarização e embeddings quando possível;
+- reservar o modelo remoto mais forte para planejamento, síntese, correções difíceis e revisão final;
+- limitar loops de reflexão e revisão por orçamento de valor esperado;
+- fazer checkpoint antes e depois de cada chamada externa;
+- pausar em vez de falhar quando a quota acabar.
 
-### Fase C — adapter experimental
+## 10. Resiliência e backpressure
 
-- feature flag `NVIDIA_NIM_ENABLED=false` por padrão;
-- allowlist de tarefas não sensíveis;
-- profile por modelo;
-- fallback para provider atual;
-- orçamento e limites configuráveis;
-- métricas e redaction.
+| Evento | Comportamento |
+|---|---|
+| `401`/`403` | bloquear somente a credencial afetada e pedir correção ao usuário |
+| `400`/`422` | não repetir; corrigir payload/capability profile |
+| `429` | persistir cooldown, respeitar `Retry-After`, reduzir ritmo e reagendar |
+| rede/DNS/socket | `network_error`, backoff com jitter e retomada |
+| `5xx` | retry limitado, circuit breaker e espera |
+| cancelamento | interromper chamada e marcar passo como cancelado, sem retry |
+| daemon reiniciado | restaurar fila, cooldowns e checkpoints |
+| provider indisponível | usar fallback permitido ou aguardar, conforme política da tarefa |
 
-### Fase D — decisão de rollout
+Não existe retry infinito. Toda política possui limite de tentativas por etapa, limite de tempo ativo, orçamento de tokens/custo e opção de espera longa.
 
-Só liberar além de experimento após Pedro aprovar:
+## 11. Estratégia de adoção
 
-- finalidade exata;
-- custo/licença;
-- limites observados e termos atualizados;
-- região/retenção;
-- modelo e capacidades verificadas;
-- rollback testado.
+1. consolidar contrato mínimo com `credentialScope`;
+2. centralizar BYOK e redaction;
+3. criar scheduler/limiter durável para ambientes restritos;
+4. executar POC NVIDIA isolada usando chave do próprio usuário;
+5. validar 40 RPM, `429`, headers, streaming, cancelamento e retomada;
+6. implementar adapter NVIDIA opcional;
+7. permitir seleção por configuração e capacidade;
+8. medir tarefas concluídas, não apenas latência;
+9. manter rollback removendo o provider da configuração.
 
-## 11. Plano de testes
+## 12. Métricas corretas para esta visão
 
-### Contrato
+Além de latência e erros, medir:
 
-- resposta simples normalizada;
-- usage ausente/presente;
-- tool calls válidas e malformadas;
-- streaming fragmentado entre chunks e `[DONE]`;
-- resposta vazia/malformada;
-- `202` tratado ou rejeitado explicitamente.
+- tarefas concluídas por 100 chamadas;
+- chamadas desperdiçadas por retry evitável;
+- tempo total em `waiting_for_quota`;
+- retomadas bem-sucedidas após reinício;
+- passos reutilizados por cache/deduplicação;
+- percentual de trabalho feito localmente;
+- falhas terminais versus pausas recuperáveis;
+- qualidade/gates aprovados por tarefa concluída;
+- consumo por `credentialScope`, sem revelar identidade ou chave.
 
-### Falhas
+O sucesso não é “respondeu em cinco segundos”. É “continuou avançando e entregou algo verificável sem estourar os recursos do usuário”.
 
-- `401`, `403`, `422`, `429`, `500`, `503`;
-- DNS, conexão recusada e queda de socket classificados como `network_error`;
-- rede desconectada;
-- timeout;
-- cancelamento pelo chamador;
-- `Retry-After` em segundos e data;
-- backoff com jitter determinístico via clock/RNG fake;
-- circuito abre, fica half-open e fecha após sucesso.
+## 13. Premissas atualizadas
 
-### Segurança
+| Premissa | Estado |
+|---|---|
+| Chave gratuita usa 40 RPM | Confirmada como baseline operacional observado em 2026 |
+| 40 RPM é contrato imutável para toda conta/modelo | Não confirmado; manter configuração e adaptação dinâmica |
+| Uma chave do projeto atenderá todos | Rejeitado; arquitetura é BYOK |
+| Paralelismo alto é necessário | Rejeitado; continuidade pode usar serialização |
+| Esperar quota é falha | Rejeitado; espera é estado persistente normal |
+| NVIDIA deve substituir todos os providers | Rejeitado; será uma opção entre providers do usuário |
+| Um agente lento não é útil | Rejeitado; qualidade acumulada e retomada são objetivos centrais |
 
-- chave não aparece em logs, eventos, erros ou snapshots;
-- headers são allowlisted;
-- prompt/resposta não são logados por padrão;
-- redaction de padrões de segredo;
-- provider experimental rejeita tarefas marcadas como sensíveis.
+## 14. Fontes
 
-### Fallback
-
-- primário saudável não chama NVIDIA;
-- erro não retryable não gera loop;
-- erro transitório respeita orçamento de retries;
-- fallback registra motivo e provider/model usados;
-- desligar feature flag restaura caminho anterior sem migração de dados.
-
-## 12. Observabilidade e rollback
-
-Métricas mínimas, sem conteúdo:
-
-- requests, sucessos e erros por `provider/model/operation`;
-- latência p50/p95/p99;
-- tokens de entrada/saída quando disponíveis;
-- retries, `429`, timeouts e circuit-open;
-- fallback count e motivo;
-- custo estimado somente quando houver tabela de preço aprovada.
-
-Rollback:
-
-1. desligar `NVIDIA_NIM_ENABLED`;
-2. retirar o modelo da allowlist;
-3. manter provider anterior como default;
-4. não persistir estado específico da NVIDIA;
-5. remover o adapter sem alterar histórico, memória ou formato de sessão.
-
-## 13. Decomposição recomendada
-
-Ordem de dependência:
-
-1. contrato mínimo de provider + capability profiles + taxonomia de erros;
-2. configuração/segredos centralizados e redaction;
-3. POC NVIDIA isolada e sem custo inesperado;
-4. resiliência genérica: retry, jitter, limiter configurável e circuit breaker;
-5. adapter NVIDIA experimental e feature flag;
-6. testes de contrato, métricas e runbook de rollout/rollback.
-
-Todas as issues de implementação devem permanecer bloqueadas até aprovação de Pedro e até o baseline da épica #34 permitir expansão arquitetural.
-
-## 14. Questões ainda abertas
-
-- Quais quotas são aplicadas à conta/chave/modelo real do projeto?
-- Quais headers de rate limit são retornados na conta de Pedro?
-- Existe retenção específica para API Catalog/NIM hosted além dos termos gerais?
-- Qual região processa e armazena as solicitações?
-- O modelo candidato mantém tool calling e usage com estabilidade suficiente?
-- A conta exige billing ou apenas Developer Program para a POC?
-
-Essas questões exigem conta/chave e, quando aplicável, confirmação contratual. Não foram simuladas como fatos.
-
-## 15. Fontes oficiais
-
-Consultadas em 2026-07-11:
+Documentação oficial consultada:
 
 - NVIDIA NIM — General FAQ: https://docs.api.nvidia.com/nim/docs/product
 - NVIDIA NIM — LLM APIs: https://docs.api.nvidia.com/nim/reference/llm-apis
-- GLM4.7 API contract: https://docs.api.nvidia.com/nim/reference/z-ai-glm4-7-infer
-- Qwen3 Coder API contract: https://docs.api.nvidia.com/nim/reference/qwen-qwen3-coder-480b-a35b-instruct-infer
-- Nemotron 3 Nano API contract: https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-30b-a3b-infer
-- NVIDIA Technology Access Terms of Use: https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA_Technology_Access_TOU.pdf
+- GLM4.7 API: https://docs.api.nvidia.com/nim/reference/z-ai-glm4-7-infer
+- Qwen3 Coder API: https://docs.api.nvidia.com/nim/reference/qwen-qwen3-coder-480b-a35b-instruct-infer
+- Nemotron 3 Nano API: https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-30b-a3b-infer
+- NVIDIA Technology Access Terms: https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA_Technology_Access_TOU.pdf
 
-## 16. Conclusão
+Evidência operacional de 40 RPM:
 
-**Recomendação final: experimentar, não migrar.**
+- https://forums.developer.nvidia.com/t/request-to-increase-nvidia-nim-api-rate-limit-from-40-rpm-to-250-300-rpm/372594
+- https://forums.developer.nvidia.com/t/request-for-nvidia-nim-api-rate-limit-increase-40-200-rpm/369472
+- https://forums.developer.nvidia.com/t/api-rate-limit-increase-for-nvidia-nim/366043
 
-A NVIDIA oferece um catálogo tecnicamente interessante e um transporte familiar, mas a oferta hospedada gratuita é explicitamente orientada a desenvolvimento, com limites operacionais não confirmados, termos incompatíveis com conteúdo sensível e diferenças de capacidade por modelo. O Ouroboros deve primeiro corrigir sua própria fragmentação de providers. Depois disso, uma POC pequena com Qwen3 Coder ou outro modelo de capacidade documentada pode gerar evidência real sem criar dependência estrutural.
+## 15. Conclusão
+
+A NVIDIA não deve ser descartada por ser lenta ou limitada. Essas limitações são precisamente o tipo de ambiente que o Ouroboros pretende dominar.
+
+A recomendação revisada é: **adotar NVIDIA NIM como provider opcional BYOK, com perfil restrito de 40 RPM, execução serial, fila durável, checkpoints e retomada**.
+
+A arquitetura não promete rapidez. Ela promete não desperdiçar a pouca capacidade disponível e continuar construindo, passo a passo, com os recursos que cada usuário possui.

--- a/docs/research/nvidia-nim-provider-evaluation-2026-07-11.md
+++ b/docs/research/nvidia-nim-provider-evaluation-2026-07-11.md
@@ -1,0 +1,369 @@
+# Avaliação da NVIDIA NIM como provider do Ouroboros
+
+- **Issue:** #42
+- **Parent:** #34
+- **Data de verificação:** 2026-07-11
+- **Natureza:** pesquisa arquitetural; nenhuma integração de produção foi implementada
+- **Resultado recomendado:** **experimentar de forma opcional e reversível**, nunca como provider principal neste ciclo
+
+## 1. Resumo executivo
+
+O produto analisado é o conjunto de **endpoints hospedados do NVIDIA API Catalog/NIM**, acessível por API compatível com o formato de Chat Completions da OpenAI em `https://integrate.api.nvidia.com/v1/chat/completions`. O NIM auto-hospedado é uma alternativa distinta, baseada em containers e infraestrutura NVIDIA.
+
+A oferta hospedada é adequada para protótipos, pesquisa, desenvolvimento e testes. A documentação oficial afirma que o acesso do NVIDIA Developer Program não é destinado a produção e não inclui estabilidade ou suporte empresarial. Uso real por usuários finais exige NVIDIA AI Enterprise. Por isso, a oferta hospedada gratuita não pode ser tratada como infraestrutura principal do Ouroboros.
+
+A hipótese de **40 requisições por minuto** não foi confirmada nas fontes oficiais consultadas. Não foi encontrada uma tabela pública estável de quota, granularidade, headers ou política por modelo/conta. O número não deve ser hardcoded.
+
+A compatibilidade com OpenAI é parcial e varia por modelo. Streaming SSE aparece nos modelos inspecionados, mas `tools` foi documentado para Qwen3 Coder e não apareceu nos contratos consultados de GLM4.7 e Nemotron 3 Nano. `response_format`/JSON Schema também não foi documentado nesses três contratos. Logo, o Ouroboros precisa de perfis de capacidade por modelo, não de uma flag genérica “OpenAI-compatible”.
+
+O principal bloqueio atual é interno: o runtime possui integrações paralelas e fortemente acopladas para Groq, Z.AI, Gemini, Antigravity e Ollama. Há uma interface `ILLMProvider`, mas ela não governa os providers usados pelo CLI atual. Integrar a NVIDIA diretamente aumentaria a fragmentação.
+
+### Decisão proposta
+
+1. Não substituir Groq, Z.AI, Gemini ou Ollama pela NVIDIA agora.
+2. Consolidar primeiro um contrato mínimo e uma taxonomia comum de erros/capacidades.
+3. Criar depois uma prova de conceito isolada do endpoint hospedado, sem dados sensíveis e sem custo não aprovado.
+4. Somente após a prova, considerar um adapter `nvidia-nim` atrás de feature flag, desligado por padrão.
+5. Manter o provider existente como caminho primário e rollback imediato.
+6. Reabrir a decisão de produção apenas com licença, custos, regiões, retenção e SLA documentados.
+
+## 2. Produto e contrato oficial
+
+### 2.1 Produto considerado
+
+| Opção | Natureza | Uso apropriado | Conclusão para o Ouroboros |
+|---|---|---|---|
+| NVIDIA API Catalog / NIM hosted endpoints | Inferência hospedada pela NVIDIA, chave de desenvolvedor, APIs por modelo | Protótipos, pesquisa, desenvolvimento e testes | Candidato apenas experimental |
+| NIM auto-hospedado | Containers de inferência executados em infraestrutura NVIDIA | Controle de dados e operação própria | Fora do ciclo atual; exige GPU/infraestrutura e avaliação de licença |
+| NVIDIA AI Enterprise | Licença e suporte empresarial para produção | Produção, estabilidade e suporte | Só considerar mediante decisão explícita de custo |
+
+A FAQ oficial apresenta o catálogo como ambiente para construir POCs e recomenda migrar para compute próprio após o protótipo. Também diferencia o Developer Program, destinado a prototipagem, do NVIDIA AI Enterprise, exigido para produção.
+
+### 2.2 Autenticação e endpoint
+
+- Autenticação: token Bearer.
+- Endpoint de chat hospedado observado: `POST https://integrate.api.nvidia.com/v1/chat/completions`.
+- Formato: descrito como compatível com Chat Completions da OpenAI.
+- O catálogo também expõe APIs distintas para embeddings, reranking, visão e outros domínios; não se deve presumir um contrato único.
+
+### 2.3 Gratuidade, créditos e produção
+
+**Confirmado:** membros do NVIDIA Developer Program possuem acesso gratuito a endpoints NIM para prototipagem e a NIMs auto-hospedáveis para pesquisa/desenvolvimento/experimentação, dentro das condições do programa.
+
+**Confirmado:** o programa gratuito não é uma licença de produção. A FAQ define produção como atividade além de desenvolvimento, teste, pesquisa ou avaliação, incluindo servir usuários reais.
+
+**Confirmado:** a documentação consultada informa que NVIDIA AI Enterprise começa em aproximadamente USD 4.500 por GPU/ano ou cerca de USD 1 por GPU/hora na nuvem. Esses números são referência do licenciamento de produção, não preço por requisição do endpoint de desenvolvimento.
+
+**Risco:** os termos permitem encerrar promoções gratuitas/descontadas, aplicar cobranças padrão após o fim da promoção ou após exceder seus termos, e alterar/depreciar tecnologia sem aviso prévio.
+
+### 2.4 Dados, privacidade e segurança
+
+Os Termos de Acesso à Tecnologia concedem à NVIDIA, afiliadas e prestadores uma licença sobre conteúdo enviado para operar, dar suporte, proteger e melhorar produtos/serviços. Salvo acordo de produto em contrário, os termos também proíbem o envio de informação confidencial, dados pessoais/controlados/sensíveis e outras categorias protegidas.
+
+Consequências para o Ouroboros hospedado:
+
+- não enviar código privado, segredos, dados pessoais ou conteúdo acadêmico/confidencial;
+- aplicar redaction antes da requisição;
+- nunca registrar chave, header Authorization, prompt integral ou resposta sensível;
+- considerar retenção, residência regional e prazo de exclusão como **desconhecidos** até existir documento específico do produto/conta;
+- tratar o endpoint gratuito como ambiente externo de desenvolvimento, não como boundary confiável de produção.
+
+## 3. Modelos e capacidades observadas
+
+A lista do catálogo é dinâmica. A tabela abaixo registra somente o contrato oficial consultado em 2026-07-11, não uma garantia permanente.
+
+| Modelo inspecionado | Chat OpenAI-style | Streaming | Tool calling documentado | Structured output documentado | `max_tokens` de saída documentado |
+|---|---:|---:|---:|---:|---:|
+| `z-ai/glm4.7` | Sim | Sim, SSE | Não localizado no contrato consultado | Não localizado | 1–32768 |
+| `qwen/qwen3-coder-480b-a35b-instruct` | Sim | Sim, SSE | Sim, campo `tools` | Não localizado | 1–16384 |
+| `nvidia/nemotron-3-nano-30b-a3b` | Sim | Sim, SSE | Não localizado no contrato consultado | Não localizado | 1–32768 |
+
+Observações:
+
+- “Não localizado” não significa que o modelo nunca suporte a capacidade; significa que ela não deve ser assumida sem prova e contrato oficial atual.
+- `max_tokens` é limite de geração documentado, não prova do contexto total.
+- Os defaults variam por modelo, inclusive `stream`; o adapter deve enviar valores explícitos.
+- O endpoint pode devolver `202` em algumas operações/modelos, portanto o contrato normalizado precisa admitir execução assíncrona ou rejeitá-la explicitamente.
+- A ausência de `response_format` nos contratos analisados impede chamar JSON por prompt de “structured output garantido”.
+
+## 4. Limites operacionais
+
+### 4.1 Hipótese de 40 RPM
+
+**Resultado:** não confirmada.
+
+Nas páginas oficiais consultadas não foi encontrada uma tabela pública que estabeleça 40 RPM como limite geral ou específico do Ouroboros. Também não foi localizado contrato público estável para:
+
+- quota por conta, chave, modelo ou endpoint;
+- requests/minuto e tokens/minuto;
+- concorrência;
+- headers de limite;
+- janela de reset;
+- comportamento formal de `429`.
+
+Portanto:
+
+- não codificar `40` como constante;
+- tornar limites configuráveis por `provider + model + operation`;
+- capturar, sem conteúdo sensível, status e headers de resposta observados na POC;
+- respeitar `Retry-After` quando presente;
+- classificar `429` como defesa genérica de gateway, sem alegar que é contrato NVIDIA confirmado.
+
+### 4.2 Política de resiliência proposta
+
+| Evento | Retry? | Política |
+|---|---:|---|
+| `401`/`403` | Não | falhar como `authentication`/`authorization`; nunca trocar chave automaticamente |
+| `400`/`422` | Não | falhar como `invalid_request`; corrigir payload/capability profile |
+| `408`, rede transitória | Sim | backoff exponencial com full jitter e limite de tentativas |
+| `429` | Sim, controlado | honrar `Retry-After`; não multiplicar carga; abrir circuito se recorrente |
+| `5xx` transitório | Sim | backoff+jitter; fallback após orçamento de tentativas |
+| timeout/cancelamento | Não automaticamente | distinguir timeout de cancelamento do usuário; propagar `AbortSignal` |
+
+Circuit breaker recomendado: chaveado por `providerId + modelId + operation`. Um estado local em memória é suficiente enquanto houver um único daemon. Só adotar estado distribuído quando houver múltiplos processos/instâncias concorrentes.
+
+## 5. Inventário da arquitetura atual
+
+### 5.1 Chamadas diretas e acoplamentos
+
+| Área | Arquivo | Provider/contrato atual | Riscos relevantes |
+|---|---|---|---|
+| Classificação de intenção | `cli/src/concierge/ConciergeClient.ts` | `groq-sdk`, modelo hardcoded | sem contrato compartilhado; fallback genérico; `console.error` |
+| Agente com tools | `cli/src/providers/direct-zai.ts` | HTTP OpenAI-style da Z.AI | modelo/base URL hardcoded; sem retry/rate limit/circuit breaker |
+| Loop de agente | `cli/src/providers/agent-loop.ts` | depende concretamente de `DirectZAIProvider` | não permite substituir provider sem refatorar o loop |
+| Review multi-modelo | `cli/src/orchestration/strategies/MultiModelReviewStrategy.ts` | fetch direto OpenAI-style | default de modelo Gemini combinado com endpoint Z.AI; falha pode virar heurística silenciosa; já coberto parcialmente por #36 |
+| Gemini | `cli/src/runtime/GeminiDirectAPI.ts` | REST específica do Google | tipos/modelos hardcoded; chave em query string; sem retry/rate limit |
+| Delegação daemon | `cli/src/daemon/rpc-gateway.ts` | roteamento por strings `gemini`, `glm`, `jules`, `antigravity` | Z.AI acoplada a wave/parser; carregamento de segredo fragmentado |
+| Inferência local | `cli/src/inference/LocalInferenceProvider.ts` | Ollama HTTP | retries e métricas locais, mas contrato exclusivo de Ollama |
+| Registry/router local | `cli/src/inference/ModelRegistry.ts`, `ModelRouter.ts`, `InferenceSubsystem.ts` | `LocalInferenceProvider` e `ollamaModel` | capacidades/roteamento não incluem dimensão de provider remoto |
+| Porta conceitual | `src/core/ports/ILLMProvider.ts` | interface mínima `chat()` | não governa os providers ativos do CLI; insuficiente para streaming, abort, usage e erros |
+| Configuração | `cli/src/utils/env-loader.ts`, `.env.example` | Groq/Google como obrigatórios | ausência de registry central de credenciais/providers; Z.AI carregada em outros pontos |
+
+### 5.2 Achados críticos
+
+1. Existem ao menos três arquiteturas de inferência em paralelo: core/ports, CLI providers remotos e subsistema local/Ollama.
+2. Compatibilidade OpenAI é usada como detalhe de transporte, mas não existe perfil formal de capacidades por modelo.
+3. Timeouts, retries, fallback, métricas e segredo são implementados de formas diferentes em cada integração.
+4. O `ModelRouter` possui circuit breaker e fallback somente no domínio de modelos locais e não controla Z.AI/Groq/Gemini.
+5. O `MultiModelReviewStrategy` já possui uma incoerência provider/model e deve ser corrigido pela #36, sem ampliar aquela issue para NVIDIA.
+6. Integrar NVIDIA diretamente em `direct-zai.ts` ou trocar apenas `baseUrl` criaria compatibilidade aparente e falhas silenciosas em tools, JSON e defaults.
+
+## 6. Compatibilidade com os fluxos do Ouroboros
+
+| Necessidade atual | NVIDIA hosted | Situação |
+|---|---|---|
+| Chat simples | Compatível nos modelos analisados | Favorável |
+| Streaming SSE | Documentado | Favorável, requer parser robusto e cancelamento |
+| Tool calling do AgentLoop | Modelo-específico | Qwen3 Coder é candidato; não assumir para GLM/Nemotron |
+| JSON para routing/review | Prompt JSON possível; schema garantido não documentado | Insuficiente para gate crítico sem validação conservadora |
+| Usage/tokens | Resposta OpenAI-style pode fornecer usage, mas deve ser validada por modelo | POC necessária |
+| Embeddings/reranking | Existem APIs específicas no catálogo | Não usar o adapter de chat como abstração universal |
+| AbortSignal/timeout | Implementável no cliente | Favorável |
+| Fallback | Responsabilidade do Ouroboros | Requer contrato e roteador comuns |
+| Custos/orçamento | Oferta de dev não equivale a produção; quota pública não confirmada | Bloqueador para default/produção |
+| Dados confidenciais | Termos gerais não permitem no uso analisado sem acordo específico | Bloqueador para tarefas sensíveis |
+
+## 7. Matriz de alternativas
+
+Escala: 1 = ruim/alto risco; 5 = favorável.
+
+| Alternativa | Custo inicial | Disponibilidade previsível | Complexidade | Lock-in | Segurança de dados | Testabilidade | Nota |
+|---|---:|---:|---:|---:|---:|---:|---|
+| NVIDIA principal | 3 | 1 | 2 | 2 | 1 | 3 | Rejeitar neste ciclo |
+| NVIDIA fallback global | 3 | 2 | 2 | 3 | 2 | 3 | Ainda amplo demais |
+| NVIDIA opcional por configuração | 4 | 3 | 3 | 4 | 3 | 4 | Recomendado após contrato/POC |
+| NVIDIA para tarefa/modelo específico | 4 | 3 | 3 | 4 | 3 | 4 | Melhor primeiro rollout |
+| Não adotar | 5 | 5 | 5 | 5 | 5 | 5 | Seguro, mas perde evidência prática |
+| NIM auto-hospedado agora | 1 | 3 | 1 | 2 | 5 | 3 | Fora do escopo/hardware atual |
+
+## 8. Premissas: confirmadas, rejeitadas e desconhecidas
+
+| Premissa | Estado | Evidência/consequência |
+|---|---|---|
+| “A NVIDIA é gratuita para desenvolvedores” | **Confirmada com qualificação** | gratuita para prototipagem/pesquisa/dev/testes no Developer Program; não é promessa de produção |
+| “O limite é 40 RPM” | **Não confirmada** | não localizada em fonte oficial consultada; proibir hardcode |
+| “É OpenAI-compatible” | **Confirmada parcialmente** | endpoint e formato de chat compatíveis; campos/capacidades variam por modelo |
+| “Todos os modelos têm tools” | **Rejeitada como premissa** | `tools` apareceu no Qwen3 Coder, não nos outros contratos analisados |
+| “JSON estruturado é garantido” | **Não confirmada** | `response_format`/schema não localizado nos três contratos |
+| “Pode substituir providers atuais” | **Rejeitada neste ciclo** | contrato de uso, quotas desconhecidas e fragmentação interna tornam a troca arriscada |
+| “Um limiter único de 40 RPM resolve” | **Rejeitada** | granularidade desconhecida; política deve ser configurável por provider/model/operação |
+| Retenção de prompts/outputs | **Desconhecida** | exigir documento específico antes de dados sensíveis |
+| Data residency/região do endpoint | **Desconhecida** | não assumir residência no Brasil/EUA |
+| SLA do endpoint gratuito | **Ausente para o caso analisado** | Developer Program não oferece estabilidade/suporte empresarial |
+
+## 9. Arquitetura alvo mínima
+
+Evitar uma abstração universal excessiva. O primeiro contrato deve cobrir apenas chat/streaming/tools usados pelo runtime.
+
+```ts
+interface ModelProvider {
+  readonly id: string;
+  capabilities(modelId: string): ModelCapabilities;
+  chat(request: ChatRequest, signal?: AbortSignal): Promise<ChatResult>;
+  stream?(request: ChatRequest, signal?: AbortSignal): AsyncIterable<ChatChunk>;
+}
+```
+
+Elementos obrigatórios do contrato normalizado:
+
+- `providerId`, `modelId`, operação e capability profile;
+- mensagens e tools normalizadas;
+- timeout externo e `AbortSignal` propagável;
+- conteúdo, tool calls, finish reason e usage;
+- status HTTP e headers permitidos para diagnóstico, sem segredo;
+- taxonomia: `authentication`, `authorization`, `invalid_request`, `rate_limited`, `timeout`, `cancelled`, `unavailable`, `provider_error`, `malformed_response`;
+- `retryable`, `retryAfterMs` e `fallbackAllowed` explícitos;
+- validação de resposta antes de entregar a gates críticos.
+
+Perfis de modelo devem declarar capacidades, não inferi-las do nome do provider:
+
+```ts
+interface ModelCapabilities {
+  chat: boolean;
+  streaming: boolean;
+  tools: boolean;
+  structuredOutput: 'none' | 'json_object' | 'json_schema';
+  embeddings: boolean;
+  reranking: boolean;
+  vision: boolean;
+  maxOutputTokens?: number;
+}
+```
+
+## 10. Plano incremental e reversível
+
+### Fase A — contrato e inventário
+
+- consolidar o contrato mínimo sem mudar o provider padrão;
+- adaptar primeiro um provider existente como prova do contrato;
+- centralizar resolução de configuração e segredo;
+- criar testes de contrato com transport fake.
+
+### Fase B — POC NVIDIA isolada
+
+- script/teste não importado pelo runtime principal;
+- chave apenas por `NVIDIA_API_KEY`;
+- modelo selecionado explicitamente;
+- chamada simples e streaming;
+- tool calling apenas em modelo cujo contrato documente `tools`;
+- JSON validado localmente;
+- credencial inválida, timeout, cancelamento e `429` simulado;
+- registrar status/headers de limite observados sem prompt/segredo;
+- nenhuma chamada paga ou teste de carga.
+
+### Fase C — adapter experimental
+
+- feature flag `NVIDIA_NIM_ENABLED=false` por padrão;
+- allowlist de tarefas não sensíveis;
+- profile por modelo;
+- fallback para provider atual;
+- orçamento e limites configuráveis;
+- métricas e redaction.
+
+### Fase D — decisão de rollout
+
+Só liberar além de experimento após Pedro aprovar:
+
+- finalidade exata;
+- custo/licença;
+- limites observados e termos atualizados;
+- região/retenção;
+- modelo e capacidades verificadas;
+- rollback testado.
+
+## 11. Plano de testes
+
+### Contrato
+
+- resposta simples normalizada;
+- usage ausente/presente;
+- tool calls válidas e malformadas;
+- streaming fragmentado entre chunks e `[DONE]`;
+- resposta vazia/malformada;
+- `202` tratado ou rejeitado explicitamente.
+
+### Falhas
+
+- `401`, `403`, `422`, `429`, `500`, `503`;
+- rede desconectada;
+- timeout;
+- cancelamento pelo chamador;
+- `Retry-After` em segundos e data;
+- backoff com jitter determinístico via clock/RNG fake;
+- circuito abre, fica half-open e fecha após sucesso.
+
+### Segurança
+
+- chave não aparece em logs, eventos, erros ou snapshots;
+- headers são allowlisted;
+- prompt/resposta não são logados por padrão;
+- redaction de padrões de segredo;
+- provider experimental rejeita tarefas marcadas como sensíveis.
+
+### Fallback
+
+- primário saudável não chama NVIDIA;
+- erro não retryable não gera loop;
+- erro transitório respeita orçamento de retries;
+- fallback registra motivo e provider/model usados;
+- desligar feature flag restaura caminho anterior sem migração de dados.
+
+## 12. Observabilidade e rollback
+
+Métricas mínimas, sem conteúdo:
+
+- requests, sucessos e erros por `provider/model/operation`;
+- latência p50/p95/p99;
+- tokens de entrada/saída quando disponíveis;
+- retries, `429`, timeouts e circuit-open;
+- fallback count e motivo;
+- custo estimado somente quando houver tabela de preço aprovada.
+
+Rollback:
+
+1. desligar `NVIDIA_NIM_ENABLED`;
+2. retirar o modelo da allowlist;
+3. manter provider anterior como default;
+4. não persistir estado específico da NVIDIA;
+5. remover o adapter sem alterar histórico, memória ou formato de sessão.
+
+## 13. Decomposição recomendada
+
+Ordem de dependência:
+
+1. contrato mínimo de provider + capability profiles + taxonomia de erros;
+2. configuração/segredos centralizados e redaction;
+3. POC NVIDIA isolada e sem custo inesperado;
+4. resiliência genérica: retry, jitter, limiter configurável e circuit breaker;
+5. adapter NVIDIA experimental e feature flag;
+6. testes de contrato, métricas e runbook de rollout/rollback.
+
+Todas as issues de implementação devem permanecer bloqueadas até aprovação de Pedro e até o baseline da épica #34 permitir expansão arquitetural.
+
+## 14. Questões ainda abertas
+
+- Quais quotas são aplicadas à conta/chave/modelo real do projeto?
+- Quais headers de rate limit são retornados na conta de Pedro?
+- Existe retenção específica para API Catalog/NIM hosted além dos termos gerais?
+- Qual região processa e armazena as solicitações?
+- O modelo candidato mantém tool calling e usage com estabilidade suficiente?
+- A conta exige billing ou apenas Developer Program para a POC?
+
+Essas questões exigem conta/chave e, quando aplicável, confirmação contratual. Não foram simuladas como fatos.
+
+## 15. Fontes oficiais
+
+Consultadas em 2026-07-11:
+
+- NVIDIA NIM — General FAQ: https://docs.api.nvidia.com/nim/docs/product
+- NVIDIA NIM — LLM APIs: https://docs.api.nvidia.com/nim/reference/llm-apis
+- GLM4.7 API contract: https://docs.api.nvidia.com/nim/reference/z-ai-glm4-7-infer
+- Qwen3 Coder API contract: https://docs.api.nvidia.com/nim/reference/qwen-qwen3-coder-480b-a35b-instruct-infer
+- Nemotron 3 Nano API contract: https://docs.api.nvidia.com/nim/reference/nvidia-nemotron-3-nano-30b-a3b-infer
+- NVIDIA Technology Access Terms of Use: https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA_Technology_Access_TOU.pdf
+
+## 16. Conclusão
+
+**Recomendação final: experimentar, não migrar.**
+
+A NVIDIA oferece um catálogo tecnicamente interessante e um transporte familiar, mas a oferta hospedada gratuita é explicitamente orientada a desenvolvimento, com limites operacionais não confirmados, termos incompatíveis com conteúdo sensível e diferenças de capacidade por modelo. O Ouroboros deve primeiro corrigir sua própria fragmentação de providers. Depois disso, uma POC pequena com Qwen3 Coder ou outro modelo de capacidade documentada pode gerar evidência real sem criar dependência estrutural.


### PR DESCRIPTION
## O que mudou

- adiciona relatório arquitetural completo para a #42;
- inventaria os providers, fila e schedulers atuais do Ouroboros;
- confirma `40 RPM` como baseline operacional observado das chaves gratuitas NVIDIA Build/NIM em 2026;
- mantém o número configurável e subordinado a `429`/`Retry-After`;
- redefine NVIDIA como provider opcional BYOK: cada usuário usa sua própria chave;
- proíbe chave central compartilhada pelo projeto;
- prioriza continuidade e qualidade acumulada, não latência;
- propõe execução serial, checkpoints, cooldown persistido e retomada após reinício;
- atualiza a ADR-0042 e a decomposição das issues.

## Decisão proposta

Adotar NVIDIA NIM como provider opcional BYOK para ambientes pessoais e restritos.

O perfil gratuito inicial usa:

```text
40 RPM por credentialScope
36 RPM de alvo nominal
maxConcurrency = 1
burst = 1
```

Quota esgotada não deve destruir a tarefa. O passo entra em `waiting_for_quota`, persiste `nextEligibleAt` e continua depois. Uma tarefa pode levar horas ou dias, desde que mantenha checkpoint, orçamento, cancelamento e validação.

Nenhuma chave do mantenedor será usada por todos. Quotas, cooldowns, métricas e circuit breakers são isolados pela credencial de cada usuário/workspace.

## Decomposição

1. #44 — contrato mínimo de provider, capacidades e contexto de credencial;
2. #45 — BYOK, secret resolution e redaction;
3. #47 — limiter, retry, cooldown e circuit breaker por credencial;
4. #50 — execução durável sob quota e recursos limitados;
5. #46 — POC NVIDIA isolada com chave do usuário;
6. #48 — adapter NVIDIA BYOK opcional;
7. #49 — contract tests, métricas de continuidade e runbook.

As issues permanecem bloqueadas pelas dependências e pelo baseline da #34. A implementação não foi iniciada.

## Impacto

Documentação e decisão arquitetural somente. Nenhuma chamada externa, dependência, chave, configuração ou comportamento de produção foi alterado.

## Validação

- documentação e termos oficiais NVIDIA verificados em 2026-07-11;
- evidência operacional de múltiplas contas gratuitas com limite de 40 RPM em fóruns NVIDIA;
- ressalva mantida: 40 RPM é default operacional, não garantia imutável por conta/modelo;
- auditoria estática de Groq, Z.AI, Gemini, Antigravity, Ollama, `PriorityTaskQueue` e `EvolutionScheduler`;
- diff contém somente os dois arquivos Markdown esperados;
- nenhuma suíte executada porque não há código.

Avança #42, que deve permanecer aberta até aprovação da ADR e evidência da POC.